### PR TITLE
Improve some return values

### DIFF
--- a/src/srpc/ly_tree.c
+++ b/src/srpc/ly_tree.c
@@ -158,7 +158,7 @@ struct lyd_node *srpc_ly_tree_get_child_choice(const struct lyd_node *node, cons
  * @param store  Variable to which the created container will be stored.
  * @param path Path of the node to create.
  *
- * @return Error code - 0 on success.
+ * @return LY_ERR on error - 0 on success.
  */
 int srpc_ly_tree_create_container(const struct ly_ctx *ly_ctx, struct lyd_node *parent, struct lyd_node **store,
                                   const char *path)
@@ -168,7 +168,7 @@ int srpc_ly_tree_create_container(const struct ly_ctx *ly_ctx, struct lyd_node *
     ly_error = lyd_new_path(parent, ly_ctx, path, NULL, 0, store);
     if (ly_error != LY_SUCCESS)
     {
-        return -1;
+        return (int)ly_error;
     }
 
     return 0;
@@ -184,7 +184,7 @@ int srpc_ly_tree_create_container(const struct ly_ctx *ly_ctx, struct lyd_node *
  * @param key Key of the list to set.
  * @param key_value Value of the key.
  *
- * @return Error code - 0 on success.
+ * @return Negative value or LY_ERR on error - 0 on success.
  */
 int srpc_ly_tree_create_list(const struct ly_ctx *ly_ctx, struct lyd_node *parent, struct lyd_node **store,
                              const char *path, const char *key, const char *key_value)
@@ -200,7 +200,7 @@ int srpc_ly_tree_create_list(const struct ly_ctx *ly_ctx, struct lyd_node *paren
     ly_error = lyd_new_path(parent, ly_ctx, path_buffer, key_value, 0, store);
     if (ly_error != LY_SUCCESS)
     {
-        return -2;
+        return (int)ly_error;
     }
 
     return 0;
@@ -261,7 +261,7 @@ int srpc_ly_tree_create_list_full(const struct ly_ctx *ly_ctx, struct lyd_node *
  * @param path Path of the node to create.
  * @param value Value of the leaf node.
  *
- * @return Error code - 0 on success.
+ * @return LY_ERR on error - 0 on success.
  */
 int srpc_ly_tree_create_leaf(const struct ly_ctx *ly_ctx, struct lyd_node *parent, struct lyd_node **store,
                              const char *path, const char *value)
@@ -271,7 +271,7 @@ int srpc_ly_tree_create_leaf(const struct ly_ctx *ly_ctx, struct lyd_node *paren
     ly_error = lyd_new_path(parent, ly_ctx, path, value, 0, store);
     if (ly_error != LY_SUCCESS)
     {
-        return -1;
+        return (int)ly_error;
     }
 
     return 0;
@@ -287,7 +287,7 @@ int srpc_ly_tree_create_leaf(const struct ly_ctx *ly_ctx, struct lyd_node *paren
  * @param path Path of the node to create.
  * @param value Value of the leaf list node to append.
  *
- * @return Error code - 0 on success.
+ * @return LY_ERR on error - 0 on success.
  */
 int srpc_ly_tree_append_leaf_list(const struct ly_ctx *ly_ctx, struct lyd_node *parent, struct lyd_node **store,
                                   const char *path, const char *value)
@@ -297,7 +297,7 @@ int srpc_ly_tree_append_leaf_list(const struct ly_ctx *ly_ctx, struct lyd_node *
     ly_error = lyd_new_path(parent, ly_ctx, path, value, 0, store);
     if (ly_error != LY_SUCCESS)
     {
-        return -1;
+        return (int)ly_error;
     }
 
     return 0;

--- a/src/srpc/ly_tree.h
+++ b/src/srpc/ly_tree.h
@@ -104,7 +104,7 @@ struct lyd_node *srpc_ly_tree_get_child_choice(const struct lyd_node *node, cons
  * @param store  Variable to which the created container will be stored.
  * @param path Path of the node to create.
  *
- * @return Error code - 0 on success.
+ * @return LY_ERR on error - 0 on success.
  */
 int srpc_ly_tree_create_container(const struct ly_ctx *ly_ctx, struct lyd_node *parent, struct lyd_node **store,
                                   const char *path);
@@ -119,7 +119,7 @@ int srpc_ly_tree_create_container(const struct ly_ctx *ly_ctx, struct lyd_node *
  * @param key Key of the list to set.
  * @param key_value Value of the key.
  *
- * @return Error code - 0 on success.
+ * @return Negative value or LY_ERR on error - 0 on success.
  */
 int srpc_ly_tree_create_list(const struct ly_ctx *ly_ctx, struct lyd_node *parent, struct lyd_node **store,
                              const char *path, const char *key, const char *key_value);
@@ -148,7 +148,7 @@ int srpc_ly_tree_create_list_full(const struct ly_ctx *ly_ctx, struct lyd_node *
  * @param path Path of the node to create.
  * @param value Value of the leaf node.
  *
- * @return Error code - 0 on success.
+ * @return LY_ERR on error - 0 on success.
  */
 int srpc_ly_tree_create_leaf(const struct ly_ctx *ly_ctx, struct lyd_node *parent, struct lyd_node **store,
                              const char *path, const char *value);
@@ -163,7 +163,7 @@ int srpc_ly_tree_create_leaf(const struct ly_ctx *ly_ctx, struct lyd_node *paren
  * @param path Path of the node to create.
  * @param value Value of the leaf list node to append.
  *
- * @return Error code - 0 on success.
+ * @return LY_ERR on error - 0 on success.
  */
 int srpc_ly_tree_append_leaf_list(const struct ly_ctx *ly_ctx, struct lyd_node *parent, struct lyd_node **store,
                                   const char *path, const char *value);


### PR DESCRIPTION
Where possible, return LY_ERR instead of -1 or -2.
Since LY_ERR is an enum (unsigned int), cast it to int.