### PR TITLE
Feat(core): add extractListKeysFromXpath() for extracting multiple keys

### DIFF
--- a/cpp/src/srpcpp/common.cpp
+++ b/cpp/src/srpcpp/common.cpp
@@ -38,6 +38,60 @@ const std::string extractListKeyFromXPath(const std::string &list, const std::st
 }
 
 /**
+ * @brief Extracts all the keys from the list XPath by list name.
+ *
+ * @param list List name.
+ * @param xpath XPath of the list.
+ * @return std::unordered_map<std::string, std::string> Key values.
+ */
+std::unordered_map<std::string, std::string> extractListKeysFromXpath(const std::string& list, const std::string& xpath)
+{
+    std::unordered_map<std::string, std::string> keys_map;
+
+    int starting_point = xpath.find(list + "[");
+    
+    std::string chunk(xpath.begin() + starting_point, xpath.end());
+    
+    int ending_point = chunk.find("]/");
+
+    if(ending_point == std::string::npos){
+        //this means it can be last
+        ending_point = chunk.find_last_of(']');
+    }
+    
+    chunk.erase(chunk.begin() + ending_point + 1, chunk.end());
+    
+    int begin = chunk.find('[');
+    int end = chunk.find(']');
+    // list is found, continue
+
+    while (begin != std::string::npos || end != std::string::npos) {
+
+        std::string mapstr(++chunk.begin() + begin, chunk.begin() + end);
+        chunk.erase(begin, ++end - begin);
+
+        // now split it by '=' in key value
+
+        int eq_pos = mapstr.find('=');
+
+        if (eq_pos == std::string::npos) {
+            throw std::runtime_error("Failed to parse '=' sympol");
+        }
+
+        std::string key(mapstr.begin(), mapstr.begin() + eq_pos);
+        // value shrink by one place begin to end to eliminate ' '
+        std::string value(mapstr.begin() + eq_pos + 2, --mapstr.end());
+
+        keys_map.insert(std::make_pair(key, value));
+
+        begin = chunk.find('[');
+        end = chunk.find(']');
+    }
+
+    return keys_map;
+}
+
+/**
  * @brief Get meta value.
  *
  * @param meta Meta collection object.

--- a/cpp/src/srpcpp/common.hpp
+++ b/cpp/src/srpcpp/common.hpp
@@ -27,6 +27,15 @@ namespace srpc
 const std::string extractListKeyFromXPath(const std::string &list, const std::string &key, const std::string &xpath);
 
 /**
+ * @brief Extracts all the keys from the list XPath by list name.
+ *
+ * @param list List name.
+ * @param xpath XPath of the list.
+ * @return std::unordered_map<std::string, std::string> Key values.
+ */
+std::unordered_map<std::string, std::string> extractListKeysFromXpath(const std::string& list, const std::string& xpath);
+
+/**
  * @brief Get meta value.
  *
  * @param meta Meta collection object.


### PR DESCRIPTION
Existing `extractListKeyFromXpath()` does not work with multiple keys in path, so with this MR, the method `extractListKeysFromXpath()` will be added, to handle that case.

`extractListKeysFromXpath()` will get a `map` with the keys in a path and their values. For exampe: 
in the path: `/testmodule:test/testpath[key1='val1'][key2='val2'][key3='val3']` it will extract the values in `unordered_map<std::string, std::string>` that will contain the key - value pairs. 